### PR TITLE
add Dependabot for pip and GitHub Actions weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuring weekly updates for `pip` and `github-actions`
- Dependabot will pin all GitHub Actions to full commit SHAs, addressing the SonarCloud security hotspots acknowledged in #NatanRigailo/mfa-app

## Test plan

- [ ] Merge and verify Dependabot appears under `Insights → Dependency graph → Dependabot`
- [ ] Confirm first PRs are opened within a few hours

Closes #6