### PR TITLE
add Dependabot Docker ecosystem support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: weekly
 
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Adds docker ecosystem to dependabot.yml to track updates to the Dockerfile base image (python:3.12-slim).

Closes #17