### PR TITLE
security: add API_TOKEN auth on /get_new_codes endpoint (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Para usar MySQL, descomente o bloco `db` no `docker-compose.yml` e defina as var
 | `APP_NAME`      | `MFA Tokens`  | Nome exibido na interface                                  |
 | `SECRET_KEY`    | gerado        | Chave Flask para sessões — defina um valor fixo em produção|
 | `EDIT_PASS`     | *(vazio)*     | Senha para ativar o modo de edição                         |
+| `API_TOKEN`     | *(vazio)*     | Se definido, exige `Authorization: Bearer <token>` em `/get_new_codes` |
 | `REGISTER_ABLE` | `true`        | Habilita o cadastro de novos tokens                        |
 | `TABLE_NAME`    | `mfa_tokens`  | Nome da tabela no banco de dados                           |
 | `MAX_UPLOAD_MB` | `5`           | Tamanho máximo do upload de QR code em MB                  |
@@ -144,7 +145,7 @@ A aplicação sobe em `http://0.0.0.0:5000` via Waitress.
 
 **Segurança**
 - [ ] Rate limiting por IP no `toggle_edit` contra força bruta ([#38](https://github.com/NatanRigailo/mfa-app/issues/38))
-- [ ] Autenticação via `API_TOKEN` no `/get_new_codes` ([#39](https://github.com/NatanRigailo/mfa-app/issues/39))
+- [x] Autenticação via `API_TOKEN` no `/get_new_codes` ([#39](https://github.com/NatanRigailo/mfa-app/issues/39))
 
 **Qualidade**
 - [ ] Suite de testes Go com `httptest` e banco in-memory ([#40](https://github.com/NatanRigailo/mfa-app/issues/40))

--- a/handler.go
+++ b/handler.go
@@ -83,6 +83,14 @@ func (a *App) healthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) getNewCodes(w http.ResponseWriter, r *http.Request) {
+	if tok := a.cfg.APIToken; tok != "" {
+		auth := r.Header.Get("Authorization")
+		if subtle.ConstantTimeCompare([]byte(auth), []byte("Bearer "+tok)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	tokens, err := a.db.activeTokens()
 	if err != nil {
 		slog.Error("get_new_codes: db error", "err", err)

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type Config struct {
 	DBDatabase   string
 	TableName    string
 	SQLitePath   string
+	APIToken     string
 }
 
 func loadConfig() Config {
@@ -63,6 +64,7 @@ func loadConfig() Config {
 		DBDatabase:   os.Getenv("DB_DATABASE"),
 		TableName:    envOr("TABLE_NAME", "mfa_tokens"),
 		SQLitePath:   envOr("SQLITE_PATH", "/data/tokens.db"),
+		APIToken:     os.Getenv("API_TOKEN"),
 	}
 }
 


### PR DESCRIPTION
Closes #39. Constant-time comparison via `crypto/subtle`. Unset token keeps the existing open behaviour.