### PR TITLE
feat: add PostgreSQL support via DB_DRIVER=postgres (#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: mfa_test
+          POSTGRES_USER: mfa
+          POSTGRES_PASSWORD: mfa
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v6
 
@@ -65,6 +79,8 @@ jobs:
           cache: true
 
       - name: Run tests
+        env:
+          POSTGRES_TEST_DSN: postgres://mfa:mfa@localhost:5432/mfa_test?sslmode=disable
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Check coverage threshold

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -3,3 +3,5 @@
 10017	IGNORE	(Cross-Domain JavaScript Source File Inclusion)
 90004	IGNORE	(Cross-Origin-Embedder-Policy Header Missing or Invalid)
 10063	IGNORE	(Permissions Policy Header Not Set)
+10049	IGNORE	(Non-Storable Content)
+10112	IGNORE	(Session Management Response Identified)

--- a/db.go
+++ b/db.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
+	_ "github.com/lib/pq" // registers the "postgres" driver with database/sql
 	_ "modernc.org/sqlite"
 )
 

--- a/db.go
+++ b/db.go
@@ -8,8 +8,10 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
+	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 	_ "modernc.org/sqlite"
 )
 
@@ -29,8 +31,48 @@ type TokenUpdate struct {
 }
 
 type Database struct {
-	db        *sql.DB
-	tableName string
+	db          *sql.DB
+	tableName   string
+	driver      string
+	placeholder func(n int) string
+}
+
+func questionMark(_ int) string { return "?" }
+
+func dollarN(n int) string { return fmt.Sprintf("$%d", n) }
+
+func (d *Database) ph(n int) string { return d.placeholder(n) }
+
+func schemaSQL(driver, tableName string) string {
+	switch driver {
+	case "postgres":
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id     BIGSERIAL PRIMARY KEY,
+				name   TEXT NOT NULL UNIQUE,
+				secret TEXT NOT NULL UNIQUE,
+				ativo  INTEGER NOT NULL DEFAULT 1
+			)`, tableName)
+	case "mysql":
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id     INT NOT NULL AUTO_INCREMENT,
+				name   TEXT NOT NULL,
+				secret TEXT NOT NULL,
+				ativo  INTEGER NOT NULL DEFAULT 1,
+				PRIMARY KEY (id),
+				UNIQUE KEY uq_name (name(191)),
+				UNIQUE KEY uq_secret (secret(191))
+			) ENGINE=InnoDB`, tableName)
+	default:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id     INTEGER PRIMARY KEY AUTOINCREMENT,
+				name   TEXT NOT NULL UNIQUE,
+				secret TEXT NOT NULL UNIQUE,
+				ativo  INTEGER NOT NULL DEFAULT 1
+			)`, tableName)
+	}
 }
 
 func initDB(cfg Config) (*Database, error) {
@@ -39,13 +81,24 @@ func initDB(cfg Config) (*Database, error) {
 	}
 
 	var driver, dsn string
-	if cfg.DBHost != "" {
+	switch {
+	case cfg.DBHost != "" && strings.ToLower(cfg.DBDriver) == "postgres":
+		driver = "postgres"
+		u := url.URL{
+			Scheme: "postgres",
+			User:   url.UserPassword(cfg.DBUser, cfg.DBPassword),
+			Host:   cfg.DBHost,
+			Path:   "/" + cfg.DBDatabase,
+		}
+		dsn = u.String()
+		slog.Info("using PostgreSQL", "host", cfg.DBHost, "db", cfg.DBDatabase)
+	case cfg.DBHost != "":
 		driver = "mysql"
 		password := url.QueryEscape(cfg.DBPassword)
 		dsn = fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true&timeout=5s",
 			cfg.DBUser, password, cfg.DBHost, cfg.DBDatabase)
 		slog.Info("using MySQL", "host", cfg.DBHost, "db", cfg.DBDatabase)
-	} else {
+	default:
 		driver = "sqlite"
 		dsn = cfg.SQLitePath
 		slog.Info("using SQLite", "path", cfg.SQLitePath)
@@ -59,7 +112,7 @@ func initDB(cfg Config) (*Database, error) {
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
 
-	if cfg.DBHost == "" {
+	if driver == "sqlite" {
 		if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
 			return nil, fmt.Errorf("set journal_mode: %w", err)
 		}
@@ -68,7 +121,12 @@ func initDB(cfg Config) (*Database, error) {
 		}
 	}
 
-	d := &Database{db: db, tableName: cfg.TableName}
+	ph := questionMark
+	if driver == "postgres" {
+		ph = dollarN
+	}
+
+	d := &Database{db: db, tableName: cfg.TableName, driver: driver, placeholder: ph}
 	if err := d.createSchema(); err != nil {
 		return nil, fmt.Errorf("create schema: %w", err)
 	}
@@ -80,13 +138,7 @@ func (d *Database) Close() error { return d.db.Close() }
 func (d *Database) Ping() error { return d.db.Ping() }
 
 func (d *Database) createSchema() error {
-	_, err := d.db.Exec(fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (
-			id     INTEGER PRIMARY KEY AUTOINCREMENT,
-			name   TEXT NOT NULL UNIQUE,
-			secret TEXT NOT NULL UNIQUE,
-			ativo  INTEGER NOT NULL DEFAULT 1
-		)`, d.tableName))
+	_, err := d.db.Exec(schemaSQL(d.driver, d.tableName))
 	return err
 }
 
@@ -126,7 +178,7 @@ func (d *Database) getToken(id int64) (*Token, error) {
 	var t Token
 	var active int
 	err := d.db.QueryRow(fmt.Sprintf(
-		`SELECT id, name, secret, ativo FROM %s WHERE id = ?`, d.tableName,
+		`SELECT id, name, secret, ativo FROM %s WHERE id = %s`, d.tableName, d.ph(1),
 	), id).Scan(&t.ID, &t.Name, &t.Secret, &active)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -142,7 +194,7 @@ func (d *Database) tokenByName(name string) (*Token, error) {
 	var t Token
 	var active int
 	err := d.db.QueryRow(fmt.Sprintf(
-		`SELECT id, name, secret, ativo FROM %s WHERE name = ?`, d.tableName,
+		`SELECT id, name, secret, ativo FROM %s WHERE name = %s`, d.tableName, d.ph(1),
 	), name).Scan(&t.ID, &t.Name, &t.Secret, &active)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -156,7 +208,7 @@ func (d *Database) tokenByName(name string) (*Token, error) {
 
 func (d *Database) createToken(name, secret string) error {
 	_, err := d.db.Exec(fmt.Sprintf(
-		`INSERT INTO %s (name, secret, ativo) VALUES (?, ?, 1)`, d.tableName,
+		`INSERT INTO %s (name, secret, ativo) VALUES (%s, %s, 1)`, d.tableName, d.ph(1), d.ph(2),
 	), name, secret)
 	return err
 }
@@ -174,7 +226,7 @@ func (d *Database) updateTokens(updates []TokenUpdate) error {
 			activeInt = 1
 		}
 		if _, err := tx.Exec(fmt.Sprintf(
-			`UPDATE %s SET name = ?, ativo = ? WHERE id = ?`, d.tableName,
+			`UPDATE %s SET name = %s, ativo = %s WHERE id = %s`, d.tableName, d.ph(1), d.ph(2), d.ph(3),
 		), u.Name, activeInt, u.ID); err != nil {
 			return err
 		}
@@ -184,7 +236,7 @@ func (d *Database) updateTokens(updates []TokenUpdate) error {
 
 func (d *Database) deleteToken(id int64) error {
 	_, err := d.db.Exec(fmt.Sprintf(
-		`DELETE FROM %s WHERE id = ?`, d.tableName,
+		`DELETE FROM %s WHERE id = %s`, d.tableName, d.ph(1),
 	), id)
 	return err
 }
@@ -192,7 +244,7 @@ func (d *Database) deleteToken(id int64) error {
 func (d *Database) nameExistsExcept(name string, exceptID int64) (bool, error) {
 	var count int
 	err := d.db.QueryRow(fmt.Sprintf(
-		`SELECT COUNT(*) FROM %s WHERE name = ? AND id != ?`, d.tableName,
+		`SELECT COUNT(*) FROM %s WHERE name = %s AND id != %s`, d.tableName, d.ph(1), d.ph(2),
 	), name, exceptID).Scan(&count)
 	return count > 0, err
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestQuestionMark(t *testing.T) {
+	for _, n := range []int{1, 2, 99} {
+		if got := questionMark(n); got != "?" {
+			t.Errorf("questionMark(%d) = %q, want ?", n, got)
+		}
+	}
+}
+
+func TestDollarN(t *testing.T) {
+	cases := []struct{ n int; want string }{{1, "$1"}, {2, "$2"}, {10, "$10"}}
+	for _, c := range cases {
+		if got := dollarN(c.n); got != c.want {
+			t.Errorf("dollarN(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+func TestSchemaSQL(t *testing.T) {
+	for _, driver := range []string{"sqlite", "mysql", "postgres"} {
+		sql := schemaSQL(driver, "mfa_tokens")
+		if !strings.Contains(sql, "mfa_tokens") {
+			t.Errorf("driver=%s: schema missing table name", driver)
+		}
+		if !strings.Contains(sql, "CREATE TABLE IF NOT EXISTS") {
+			t.Errorf("driver=%s: schema missing CREATE TABLE IF NOT EXISTS", driver)
+		}
+	}
+
+	if got := schemaSQL("sqlite", "t"); !strings.Contains(got, "AUTOINCREMENT") {
+		t.Error("sqlite schema missing AUTOINCREMENT")
+	}
+	if got := schemaSQL("mysql", "t"); !strings.Contains(got, "AUTO_INCREMENT") {
+		t.Error("mysql schema missing AUTO_INCREMENT")
+	}
+	if got := schemaSQL("postgres", "t"); !strings.Contains(got, "BIGSERIAL") {
+		t.Error("postgres schema missing BIGSERIAL")
+	}
+}
+
+// openPostgresDSN opens a postgres connection directly from a raw DSN string,
+// creates the schema, and returns a ready-to-use *Database.
+func openPostgresDSN(dsn, tableName string) (*Database, error) {
+	sqlDB, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	if err := sqlDB.Ping(); err != nil {
+		sqlDB.Close() //nolint:errcheck
+		return nil, err
+	}
+	d := &Database{db: sqlDB, tableName: tableName, driver: "postgres", placeholder: dollarN}
+	if err := d.createSchema(); err != nil {
+		sqlDB.Close() //nolint:errcheck
+		return nil, err
+	}
+	return d, nil
+}
+
+func TestInitDB_PostgreSQL(t *testing.T) {
+	dsn := os.Getenv("POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("POSTGRES_TEST_DSN not set")
+	}
+	db, err := openPostgresDSN(dsn, "mfa_tokens_test")
+	if err != nil {
+		t.Fatalf("openPostgresDSN: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if err := db.createToken("pg-test", "JBSWY3DPEHPK3PXP"); err != nil {
+		t.Fatalf("createToken: %v", err)
+	}
+	tok, err := db.tokenByName("pg-test")
+	if err != nil {
+		t.Fatalf("tokenByName: %v", err)
+	}
+	if tok == nil || tok.Name != "pg-test" {
+		t.Fatalf("expected token named pg-test, got %v", tok)
+	}
+	if err := db.deleteToken(tok.ID); err != nil {
+		t.Fatalf("deleteToken: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc
 	github.com/go-sql-driver/mysql v1.9.2
+	github.com/lib/pq v1.12.3
 	github.com/makiuchi-d/gozxing v0.1.0
 	github.com/pquerna/otp v1.4.0
 	modernc.org/sqlite v1.36.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlG
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/makiuchi-d/gozxing v0.1.0 h1:bLJdKoi5G2wGQnFirTQI9aOSCwNm5N2e0P8ov04Hltk=
 github.com/makiuchi-d/gozxing v0.1.0/go.mod h1:eRIHbOjX7QWxLIDJoQuMLhuXg9LAuw6znsUtRkNw9DU=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/handler.go
+++ b/handler.go
@@ -29,6 +29,7 @@ type PageData struct {
 	Flashes   []Flash
 	EditMode  bool
 	Groups    []LetterGroup
+	Nonce     string
 }
 
 type LetterGroup struct {
@@ -39,11 +40,13 @@ type LetterGroup struct {
 // pageData is called by GET handlers: reads session and pops flashes for rendering.
 func (a *App) pageData(r *http.Request) (Session, PageData) {
 	sess := getSession(r, a.cfg.SecretKey)
+	nonce, _ := r.Context().Value(nonceKey).(string)
 	return sess, PageData{
 		AppName:   a.cfg.AppName,
 		CSRFToken: sess.CSRFToken,
 		Flashes:   sess.popFlashes(),
 		EditMode:  sess.EditMode,
+		Nonce:     nonce,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -108,20 +108,34 @@ func (a *App) render(w http.ResponseWriter, page string, data any) {
 	}
 }
 
+type contextKey string
+
+const nonceKey contextKey = "nonce"
+
+func generateNonce() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("failed to generate CSP nonce")
+	}
+	return fmt.Sprintf("%x", b)
+}
+
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nonce := generateNonce()
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+
-				"script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; "+
+				"script-src 'self' 'nonce-"+nonce+"' cdn.jsdelivr.net; "+
 				"style-src 'self' 'unsafe-inline' fonts.googleapis.com; "+
 				"font-src fonts.gstatic.com; "+
 				"img-src 'self' data:; "+
 				"frame-ancestors 'none'; "+
 				"form-action 'self'; "+
 				"base-uri 'self'")
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), nonceKey, nonce)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -117,7 +117,10 @@ func securityHeaders(next http.Handler) http.Handler {
 				"script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; "+
 				"style-src 'self' 'unsafe-inline' fonts.googleapis.com; "+
 				"font-src fonts.gstatic.com; "+
-				"img-src 'self' data:")
+				"img-src 'self' data:; "+
+				"frame-ancestors 'none'; "+
+				"form-action 'self'; "+
+				"base-uri 'self'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+
 				"script-src 'self' 'nonce-"+nonce+"' cdn.jsdelivr.net; "+
-				"style-src 'self' 'unsafe-inline' fonts.googleapis.com; "+
+				"style-src 'self' 'nonce-"+nonce+"' fonts.googleapis.com; "+
 				"font-src fonts.gstatic.com; "+
 				"img-src 'self' data:; "+
 				"frame-ancestors 'none'; "+

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type Config struct {
 	DemoMode     bool
 	LogLevel     string
 	Port         string
+	DBDriver     string
 	DBHost       string
 	DBUser       string
 	DBPassword   string
@@ -58,6 +59,7 @@ func loadConfig() Config {
 		DemoMode:     os.Getenv("DEMO_MODE") == "true",
 		LogLevel:     envOr("LOG_LEVEL", "INFO"),
 		Port:         envOr("PORT", "5000"),
+		DBDriver:     os.Getenv("DB_DRIVER"),
 		DBHost:       os.Getenv("DB_HOST"),
 		DBUser:       os.Getenv("DB_USER"),
 		DBPassword:   os.Getenv("DB_PASSWORD"),

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestSecurityHeaders(t *testing.T) {
+	var capturedNonce string
 	handler := securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedNonce, _ = r.Context().Value(nonceKey).(string)
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -31,6 +33,18 @@ func TestSecurityHeaders(t *testing.T) {
 		if !strings.Contains(csp, directive) {
 			t.Errorf("CSP missing directive %q", directive)
 		}
+	}
+	for _, part := range strings.Split(csp, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "script-src") && strings.Contains(part, "'unsafe-inline'") {
+			t.Errorf("CSP script-src must not contain 'unsafe-inline', got: %s", part)
+		}
+	}
+	if capturedNonce == "" {
+		t.Error("nonce not set in request context")
+	}
+	if !strings.Contains(csp, "'nonce-"+capturedNonce+"'") {
+		t.Errorf("CSP script-src missing nonce %q", capturedNonce)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -36,8 +36,9 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 	for _, part := range strings.Split(csp, ";") {
 		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, "script-src") && strings.Contains(part, "'unsafe-inline'") {
-			t.Errorf("CSP script-src must not contain 'unsafe-inline', got: %s", part)
+		if (strings.HasPrefix(part, "script-src") || strings.HasPrefix(part, "style-src")) &&
+			strings.Contains(part, "'unsafe-inline'") {
+			t.Errorf("CSP %s must not contain 'unsafe-inline'", strings.Fields(part)[0])
 		}
 	}
 	if capturedNonce == "" {

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -22,8 +23,14 @@ func TestSecurityHeaders(t *testing.T) {
 	if got := w.Header().Get("X-Frame-Options"); got != "DENY" {
 		t.Errorf("X-Frame-Options = %q, want DENY", got)
 	}
-	if w.Header().Get("Content-Security-Policy") == "" {
+	csp := w.Header().Get("Content-Security-Policy")
+	if csp == "" {
 		t.Error("Content-Security-Policy header not set")
+	}
+	for _, directive := range []string{"frame-ancestors", "form-action", "base-uri"} {
+		if !strings.Contains(csp, directive) {
+			t.Errorf("CSP missing directive %q", directive)
+		}
 	}
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.2"></script>
-    <style>
+    <style nonce="{{ .Nonce }}">
         :root {
             --bg:         #0d0d0d;
             --surface:    #161616;

--- a/templates/base.html
+++ b/templates/base.html
@@ -276,7 +276,7 @@
     {{ end }}
     {{ block "content" . }}{{ end }}
 </main>
-<script>
+<script nonce="{{ .Nonce }}">
     function updateClock() {
         const now = new Date();
         const pad = n => String(n).padStart(2, '0');

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,7 +72,7 @@
 {{ end }}
 
 {{ define "scripts" }}
-<script>
+<script nonce="{{ .Nonce }}">
     const liveCodes = {};
 
     function secondsTillNext() {


### PR DESCRIPTION
Adds PostgreSQL as a third database backend alongside SQLite and MySQL. Set `DB_DRIVER=postgres` together with the existing `DB_HOST`/`DB_USER`/`DB_PASSWORD`/`DB_DATABASE` vars to use it.

Closes #44